### PR TITLE
Add prometheus support

### DIFF
--- a/ggircd.conf
+++ b/ggircd.conf
@@ -7,5 +7,9 @@
   "DefaultChannelMode": "t",
   "DefaultUserMode":    "i",
 
-  "SpoofHostName": "i.love.plan9.bell-labs.com"
+  "SpoofHostName": "i.love.plan9.bell-labs.com",
+
+  "Prometheus": {
+    "Port": 8080
+  }
 }

--- a/irc/config.go
+++ b/irc/config.go
@@ -22,6 +22,10 @@ type Config struct {
 	PingFrequency  int
 	PongMaxLatency int
 
+	Prometheus struct {
+		Port int
+	}
+
 	SSLCertificate SSLCertificate
 }
 

--- a/irc/connection.go
+++ b/irc/connection.go
@@ -51,6 +51,7 @@ func (c *connectionImpl) send(msg message) {
 }
 
 func (c *connectionImpl) loop() {
+	active_connections.Inc()
 	go c.writeLoop()
 	go c.readLoop()
 	c.pingLoop()
@@ -98,6 +99,7 @@ func (c *connectionImpl) readLoop() {
 	}
 
 	c.conn.Close()
+	active_connections.Dec()
 
 	// If there was never a QUIT message then this is a premature termination and
 	// a quit message should be faked.

--- a/irc/handler_user.go
+++ b/irc/handler_user.go
@@ -1,5 +1,9 @@
 package irc
 
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
 type commandMap map[string]func(state, *user, connection, message) handler
 
 // userHandler is a handler that handles messages coming from a user connection
@@ -47,6 +51,13 @@ func (h *userHandler) closed(conn connection) {
 func (h *userHandler) handle(conn connection, msg message) handler {
 	state := <-h.state
 	defer func() { h.state <- state }()
+
+	command_received.With(
+		prometheus.Labels{
+			"nick":    h.nick,
+			"command": msg.command,
+		},
+	).Inc()
 
 	command := h.commands[msg.command]
 	if command == nil {

--- a/irc/prometheus.go
+++ b/irc/prometheus.go
@@ -4,8 +4,23 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
+
+var (
+	command_received = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "command_received_total",
+			Help: "Number of irc commands received.",
+		},
+		[]string{"nick", "command"},
+	)
+)
+
+func init() {
+	prometheus.MustRegister(command_received)
+}
 
 // runPrometheus starts an HTTP server with a /metrics endpoint for publishing
 // Prometheus metrics. This method does not return and should be run in a

--- a/irc/prometheus.go
+++ b/irc/prometheus.go
@@ -9,6 +9,11 @@ import (
 )
 
 var (
+	active_connections = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "active_connections",
+			Help: "The number of active connections.",
+		})
 	command_received = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "command_received_total",
@@ -16,16 +21,19 @@ var (
 		},
 		[]string{"nick", "command"},
 	)
-	active_connections = prometheus.NewGauge(
+	nicks_in_channel = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "active_connections",
-			Help: "The number of active connections.",
-		})
+			Name: "nicks_in_channel",
+			Help: "The number of nicks in a channel.",
+		},
+		[]string{"channel"},
+	)
 )
 
 func init() {
-	prometheus.MustRegister(command_received)
 	prometheus.MustRegister(active_connections)
+	prometheus.MustRegister(command_received)
+	prometheus.MustRegister(nicks_in_channel)
 }
 
 // runPrometheus starts an HTTP server with a /metrics endpoint for publishing

--- a/irc/prometheus.go
+++ b/irc/prometheus.go
@@ -1,0 +1,17 @@
+package irc
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+// runPrometheus starts an HTTP server with a /metrics endpoint for publishing
+// Prometheus metrics. This method does not return and should be run in a
+// goroutine.
+func runPrometheus(cfg Config) {
+	http.Handle("/metrics", promhttp.Handler())
+	var port string = fmt.Sprintf(":%d", cfg.Prometheus.Port)
+	logf(fatal, "Http server error: %d", http.ListenAndServe(port, nil))
+}

--- a/irc/prometheus.go
+++ b/irc/prometheus.go
@@ -16,10 +16,16 @@ var (
 		},
 		[]string{"nick", "command"},
 	)
+	active_connections = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "active_connections",
+			Help: "The number of active connections.",
+		})
 )
 
 func init() {
 	prometheus.MustRegister(command_received)
+	prometheus.MustRegister(active_connections)
 }
 
 // runPrometheus starts an HTTP server with a /metrics endpoint for publishing

--- a/irc/server.go
+++ b/irc/server.go
@@ -13,6 +13,8 @@ func RunServer(cfg Config) {
 		logf(fatal, "Could not create server: %v", err)
 	}
 
+	go runPrometheus(cfg)
+
 	var lnSSL net.Listener
 	certFile := cfg.SSLCertificate.CertFile
 	keyFile := cfg.SSLCertificate.KeyFile


### PR DESCRIPTION
This PR adds Prometheus metrics to ggircd. Besides default go metrics (gc pauses, memory usage, threads, etc), it adds a Counter with nick and command labels.