### PR TITLE
Run Prometheus if requested only

### DIFF
--- a/irc/server.go
+++ b/irc/server.go
@@ -13,7 +13,9 @@ func RunServer(cfg Config) {
 		logf(fatal, "Could not create server: %v", err)
 	}
 
-	go runPrometheus(cfg)
+	if cfg.Prometheus.Port != 0 {
+		go runPrometheus(cfg)
+	}
 
 	var lnSSL net.Listener
 	certFile := cfg.SSLCertificate.CertFile


### PR DESCRIPTION
Currently there is no way to launch a server without Prometheus metrics server. If you specify `Config.Prometheus.Port = 0`, Prometheus server will launch on random port. This changes will fix this behavior.