### PR TITLE
Bump travis go version to 1.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: go
 notifications:
   email: false
+go:
+- 1.13.x


### PR DESCRIPTION
Prometheus now requires go1.13 to compile whereas travis defaults to
1.11.